### PR TITLE
Fix `r` and `s` size to 32-bytes

### DIFF
--- a/src/asn1-parser.spec.ts
+++ b/src/asn1-parser.spec.ts
@@ -28,15 +28,12 @@ describe("parsePublicKey", () => {
 });
 
 describe("parseSignature", () => {
-  it("ok", () => {
+  it("ok with 142-length signature", () => {
     const buf = Buffer.from(
       "304502201fa98c7c5f1b964a6b438d9283adf30519aaea2d1a2b25ac473ac0f85d6e08c0022100e26f7c547cf497959af070ec7c43ebdbb3e4341395912d6ccc950b43e886781b",
       "hex"
     );
     const signature = parseSignature(buf);
-
-    expect(signature.r.length).toBe(32);
-    expect(signature.s.length).toBe(32);
 
     expect(signature.r.toString("hex")).toBe(
       "1fa98c7c5f1b964a6b438d9283adf30519aaea2d1a2b25ac473ac0f85d6e08c0"
@@ -45,5 +42,27 @@ describe("parseSignature", () => {
     expect(signature.s.toString("hex")).toBe(
       "e26f7c547cf497959af070ec7c43ebdbb3e4341395912d6ccc950b43e886781b"
     );
+
+    expect(signature.r.length).toBe(32);
+    expect(signature.s.length).toBe(32);
+  });
+
+  it("ok with 140-length signature", () => {
+    const buf = Buffer.from(
+      "30440221009c68bf9b88814142fef77d95956b21625789c34fde9b853653b24fc23515577f021f74e3e4d71e7385ae71042b0f99f7fbbf66e7760dd513ed2fcea754e2a9131c",
+      "hex"
+    );
+    const signature = parseSignature(buf);
+
+    expect(signature.r.toString("hex")).toBe(
+      "9c68bf9b88814142fef77d95956b21625789c34fde9b853653b24fc23515577f"
+    );
+
+    expect(signature.s.toString("hex")).toBe(
+      "0074e3e4d71e7385ae71042b0f99f7fbbf66e7760dd513ed2fcea754e2a9131c"
+    );
+
+    expect(signature.r.length).toBe(32);
+    expect(signature.s.length).toBe(32);
   });
 });

--- a/src/asn1-parser.ts
+++ b/src/asn1-parser.ts
@@ -20,9 +20,7 @@ function pad(params: {
 }): Buffer {
   const { buffer, length, element } = params;
 
-  const padding = Buffer.from(
-    [...Array(length - buffer.length)].map((x) => element)
-  );
+  const padding = Buffer.alloc(length - buffer.length, element);
   return Buffer.concat([padding, buffer]);
 }
 
@@ -37,7 +35,7 @@ export function parsePublicKey(buf: Buffer) {
 /**
  * Parse signature from the given signature.
  * @param buf The buffer of the signature which following ASN.1 format.
- * @returns The set consists of, `r` and `s`. The `r` and `s` are parsed from the given signature and converted to 32 statically sized format from ASN.1 format. For example, if there is 33-bytes unsigned integer  formatted by ASN.1, it will be converted into 32-length bytes which dropped the first byte. (e.g. `00e26f7c547cf497959af070ec7c43ebdbb3e4341395912d6ccc950b43e886781b` → `00e26f7c547cf497959af070ec7c43ebdbb3e4341395912d6ccc950b43e886781b`). And, if there is 31-bytes integer formatted by ASN.1, it will be padded into 32-length bytes with `0` byte. (e.g. `74e3e4d71e7385ae71042b0f99f7fbbf66e7760dd513ed2fcea754e2a9131c` → `0074e3e4d71e7385ae71042b0f99f7fbbf66e7760dd513ed2fcea754e2a9131c`).
+ * @returns The set consists of, `r` and `s`. The `r` and `s` are parsed from the given signature and converted to 32 statically sized format from ASN.1 format. For example, if there is 33-bytes unsigned integer  formatted by ASN.1, it will be converted into 32-length bytes which dropped the first byte. (e.g. `00e26f7c547cf497959af070ec7c43ebdbb3e4341395912d6ccc950b43e886781b` → `e26f7c547cf497959af070ec7c43ebdbb3e4341395912d6ccc950b43e886781b`). And, if there is 31-bytes integer formatted by ASN.1, it will be padded into 32-length bytes with `0` byte. (e.g. `74e3e4d71e7385ae71042b0f99f7fbbf66e7760dd513ed2fcea754e2a9131c` → `0074e3e4d71e7385ae71042b0f99f7fbbf66e7760dd513ed2fcea754e2a9131c`).
  */
 export function parseSignature(buf: Buffer): { r: Buffer; s: Buffer } {
   const { result } = asn1js.fromBER(toArrayBuffer(buf));

--- a/src/asn1-parser.ts
+++ b/src/asn1-parser.ts
@@ -9,6 +9,23 @@ function toArrayBuffer(buffer: Buffer) {
   return ab;
 }
 
+function isUnsignedInteger(buffer: Buffer) {
+  return buffer[0] === 0;
+}
+
+function pad(params: {
+  buffer: Buffer;
+  length: number;
+  element: number;
+}): Buffer {
+  const { buffer, length, element } = params;
+
+  const padding = Buffer.from(
+    [...Array(length - buffer.length)].map((x) => element)
+  );
+  return Buffer.concat([padding, buffer]);
+}
+
 export function parsePublicKey(buf: Buffer) {
   const { result } = asn1js.fromBER(toArrayBuffer(buf));
   const values = (result as asn1js.Sequence).valueBlock.value;
@@ -17,16 +34,40 @@ export function parsePublicKey(buf: Buffer) {
   return Buffer.from(value.valueBlock.valueHex.slice(1));
 }
 
-export function parseSignature(buf: Buffer) {
+/**
+ * Parse signature from the given signature.
+ * @param buf The buffer of the signature which following ASN.1 format.
+ * @returns The set consists of, `r` and `s`. The `r` and `s` are parsed from the given signature and converted to 32 statically sized format from ASN.1 format. For example, if there is 33-bytes unsigned integer  formatted by ASN.1, it will be converted into 32-length bytes which dropped the first byte. (e.g. `00e26f7c547cf497959af070ec7c43ebdbb3e4341395912d6ccc950b43e886781b` → `00e26f7c547cf497959af070ec7c43ebdbb3e4341395912d6ccc950b43e886781b`). And, if there is 31-bytes integer formatted by ASN.1, it will be padded into 32-length bytes with `0` byte. (e.g. `74e3e4d71e7385ae71042b0f99f7fbbf66e7760dd513ed2fcea754e2a9131c` → `0074e3e4d71e7385ae71042b0f99f7fbbf66e7760dd513ed2fcea754e2a9131c`).
+ */
+export function parseSignature(buf: Buffer): { r: Buffer; s: Buffer } {
   const { result } = asn1js.fromBER(toArrayBuffer(buf));
   const values = (result as asn1js.Sequence).valueBlock.value;
 
-  const getHex = (value: asn1js.Integer) => {
-    const buf = Buffer.from(value.valueBlock.valueHex);
-    return buf.slice(Math.max(buf.length - 32, 0));
-  };
+  const getHex = (value: asn1js.Integer) =>
+    Buffer.from(value.valueBlock.valueHex);
 
-  const r = getHex(values[0] as asn1js.Integer);
-  const s = getHex(values[1] as asn1js.Integer);
+  let r = getHex(values[0] as asn1js.Integer);
+  let s = getHex(values[1] as asn1js.Integer);
+
+  if (isUnsignedInteger(r)) {
+    r = r.slice(1);
+  }
+
+  if (isUnsignedInteger(s)) {
+    s = s.slice(1);
+  }
+
+  r = pad({
+    buffer: r,
+    length: 32,
+    element: 0,
+  });
+
+  s = pad({
+    buffer: s,
+    length: 32,
+    element: 0,
+  });
+
   return { r, s };
 }


### PR DESCRIPTION
This pull request resolves #281.

The AWS KMS signs and responses with a signature formatted by ASN.1. And ASN.1 format serialize integer with `\x00` byte as prefix if it can be confused with negative integer. It serializes with only least bytes. So the integers, `r` and `s`, can be 33-bytes and 31-bytes.

The parameter `signature` of `secp256k1.ecdsaRecover` requires 64-bytes consists of 32-bytes `r` and 32-bytes `s`. So it is checking the condition.
https://github.com/odanado/aws-kms-provider/blob/ca5d7da4bfbf382cd2c14002d5efb0ba62b8ad25/src/crypto.ts#L33-L38
But the original code didn't care 31-bytes case. So I tried to fix the bug.