### PR TITLE
chore(ci): remove pull_request

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    types: [opened, synchronize, reopened]
   pull_request_target:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -13,7 +11,6 @@ on:
 jobs:
   setup:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
 
     strategy:
       matrix:
@@ -54,7 +51,6 @@ jobs:
   test-unit:
     needs: [setup]
     runs-on: ubuntu-latest
-    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
 
     strategy:
       matrix:
@@ -96,7 +92,6 @@ jobs:
   test-e2e:
     needs: [setup]
     runs-on: ubuntu-latest
-    if: (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
 
     strategy:
       matrix:


### PR DESCRIPTION
`secrets` isn't passed to GitHub Actions in the pull_request event of a pull request from a forked repository.
This means that external collaborators will not be able to run e2e tests (e.g. #283)

So we will change the event to pull_request_target.