### PR TITLE
Add a hardfork for custom chain

### DIFF
--- a/packages/aws-kms-provider/src/provider.ts
+++ b/packages/aws-kms-provider/src/provider.ts
@@ -33,6 +33,8 @@ export interface NetworkOptions {
   chainName: string;
   chainId: number;
   networkId: number;
+  hardfork?: string;
+  supportedHardforks?: Array<string>;
 }
 
 export class KmsProvider implements Provider {
@@ -197,7 +199,16 @@ export class KmsProvider implements Provider {
     if (isNetworkOptions(this.networkOrNetworkOptions)) {
       const networkOptions = this.networkOrNetworkOptions;
       return {
-        common: Common.forCustomChain("mainnet", networkOptions, "petersburg"),
+        common: Common.forCustomChain(
+          "mainnet",
+          {
+            name: networkOptions.chainName,
+            chainId: networkOptions.chainId,
+            networkId: networkOptions.networkId,
+          },
+          networkOptions.hardfork || "petersburg",
+          networkOptions.supportedHardforks
+        ),
       };
     }
 


### PR DESCRIPTION
Hello,

I have used the KmsProvider to deploy my project to my Hyperledger Besu as a private network. It returns an error

```
Error:  *** Deployment Failed ***

"Migrations" -- Method called with neither a hardfork set nor provided by param.

...
```

So, I investigated and found that a hardfork setting was missing in `forCustomChain`.

After testing, it works fine.

P.S. For the current source code version, I am curious that `forCustomChain` has hardcoded as `petersburg`. Would it be better if it could adjust via the constructor?