### PR TITLE
fix(aws-kms-provider): remove calling start method of web3-provider-engine

### DIFF
--- a/aws-kms-packages/aws-kms-provider/src/provider.ts
+++ b/aws-kms-packages/aws-kms-provider/src/provider.ts
@@ -92,8 +92,6 @@ export class KmsProvider implements Provider {
     );
 
     this.engine.addProvider(new RpcSubprovider({ rpcUrl: endpoint }));
-
-    this.engine.start();
   }
 
   public async getAccounts(): Promise<string[]> {


### PR DESCRIPTION
Close: #299